### PR TITLE
Updating readme to include spawner instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ To install this extension into JupyterLab, do the following:
 jupyter labextension install @jupyterlab/hub-extension
 ```
 
+In `jupyterhub_config.py` configure the Spawner to tell the single-user notebook servers to default to Jupyter-Lab:
+
+```
+c.Spawner.default_url = '/lab'
+```
+
 You will also need to start the single user servers in JupyterHub using the following command (that ships with JupyterLab):
 
 ```bash


### PR DESCRIPTION
Added a line similar to what is in the readthedocs for jupyter hub to explain steps required to work with spawners. 