### PR TITLE
Add standardized package keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "keywords": [
     "jupyter",
-    "jupyterlab"
+    "jupyterlab",
+    "jupyterlab-extension"
   ],
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
By having a standardized package keyword, we ease discoverability on npm registries, e.g. with `npm search`. See https://github.com/jupyterlab/jupyterlab/issues/3841 for a discussion on the choice of keyword.