### PR TITLE
Bump version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab/hub-extension",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "JupyterLab integration for JupyterHub.",
   "author": "Project Jupyter",
   "main": "lib/index.js",


### PR DESCRIPTION
Fixes #60.
Well, not really, it should be already fixed as I've published it. But this keeps the version number correct.