### PR TITLE
Check for running server and prompt to restart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,17 +4,61 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@jupyterlab/application": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/application/-/application-0.19.1.tgz",
-      "integrity": "sha512-SyfJyXmAPBtlJbvyuvMqOM6nIjsXDElXbDs+YKJRGET7pm3PZ85Zz3YZ1qyoJtH/CUcUQU1ihqqAHcm2H5MQ7w==",
+    "@babel/runtime": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.2.tgz",
+      "integrity": "sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==",
       "requires": {
-        "@jupyterlab/apputils": "^0.19.1",
-        "@jupyterlab/coreutils": "^2.2.1",
-        "@jupyterlab/docregistry": "^0.19.1",
-        "@jupyterlab/rendermime": "^0.19.1",
-        "@jupyterlab/rendermime-interfaces": "^1.2.1",
-        "@jupyterlab/services": "^3.2.1",
+        "regenerator-runtime": "^0.13.2"
+      }
+    },
+    "@blueprintjs/core": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/core/-/core-3.14.1.tgz",
+      "integrity": "sha512-DlBkztfvk5RgD+MBo22LFxLa7Rz8DVgszNdXF0MY63QGjb1uYwdSJIKXtsN1bn42SRTz24Bzp498VhSJ2+5FuQ==",
+      "requires": {
+        "@blueprintjs/icons": "^3.6.0",
+        "@types/dom4": "^2.0.1",
+        "classnames": "^2.2",
+        "dom4": "^2.0.1",
+        "normalize.css": "^8.0.0",
+        "popper.js": "^1.14.1",
+        "react-popper": "^1.0.0",
+        "react-transition-group": "^2.2.1",
+        "resize-observer-polyfill": "^1.5.0",
+        "tslib": "^1.9.0"
+      }
+    },
+    "@blueprintjs/icons": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/icons/-/icons-3.6.0.tgz",
+      "integrity": "sha512-sgB6rJtMjc2mS4aCS+65gK5DCr8fiWgOYi0buc0ODvGD2fwOtOFZuE4Duuj6/GZnCYj4s7E8NZgYK9Krd7G73Q==",
+      "requires": {
+        "classnames": "^2.2",
+        "tslib": "^1.9.0"
+      }
+    },
+    "@blueprintjs/select": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@blueprintjs/select/-/select-3.7.0.tgz",
+      "integrity": "sha512-T3mj6h3NjbxsSJlDvkgi0AJYQc/pcxtynV2t0tlTysasOHcw/iQ3+/LKZdhb1UWobttOkpWDKR06NPJWJHLIlw==",
+      "requires": {
+        "@blueprintjs/core": "^3.14.0",
+        "classnames": "^2.2",
+        "tslib": "^1.9.0"
+      }
+    },
+    "@jupyterlab/application": {
+      "version": "1.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/application/-/application-1.0.0-alpha.3.tgz",
+      "integrity": "sha512-pSnCy8snfnrTjAHCS8Q4GHQTdDxsAmnobEy5pBBrRf8GPVzKbvwgZl89l4z39/wLmBQNW1fh6mB8XMKw2CiuDg==",
+      "requires": {
+        "@jupyterlab/apputils": "^1.0.0-alpha.3",
+        "@jupyterlab/coreutils": "^3.0.0-alpha.3",
+        "@jupyterlab/docregistry": "^1.0.0-alpha.3",
+        "@jupyterlab/rendermime": "^1.0.0-alpha.3",
+        "@jupyterlab/rendermime-interfaces": "^1.3.0-alpha.3",
+        "@jupyterlab/services": "^4.0.0-alpha.3",
         "@phosphor/algorithm": "^1.1.2",
         "@phosphor/application": "^1.6.0",
         "@phosphor/commands": "^1.6.1",
@@ -23,16 +67,18 @@
         "@phosphor/messaging": "^1.2.2",
         "@phosphor/properties": "^1.1.2",
         "@phosphor/signaling": "^1.2.2",
-        "@phosphor/widgets": "^1.6.0"
+        "@phosphor/widgets": "^1.6.0",
+        "font-awesome": "~4.7.0"
       }
     },
     "@jupyterlab/apputils": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-0.19.1.tgz",
-      "integrity": "sha512-//vajDyVyKwXU7qycRBJC37dljjWeya+YpJV3z5sSXgVBefEBZ0kcrJ92ugDSht4I4SRv6x+kw6K9mBXKaYu9Q==",
+      "version": "1.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-1.0.0-alpha.3.tgz",
+      "integrity": "sha512-Z799w0p0Gaavk4EF7oOU/WcwItLiN01Q1ltpCqdXRVOUh7S/PDxaPXqUX0grFjp3Vr4W5F4C/+/YdnHEAEIu+A==",
       "requires": {
-        "@jupyterlab/coreutils": "^2.2.1",
-        "@jupyterlab/services": "^3.2.1",
+        "@jupyterlab/coreutils": "^3.0.0-alpha.3",
+        "@jupyterlab/services": "^4.0.0-alpha.3",
+        "@jupyterlab/ui-components": "^1.0.0-alpha.3",
         "@phosphor/algorithm": "^1.1.2",
         "@phosphor/commands": "^1.6.1",
         "@phosphor/coreutils": "^1.3.0",
@@ -50,47 +96,49 @@
       }
     },
     "@jupyterlab/codeeditor": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-0.19.1.tgz",
-      "integrity": "sha512-mCL4YiCCX5JOAIs21mleSmlkejAw6FVLwmvKGxBCwoNj+cSYUKzGBYuA2xvxAZi/5HaiQU8R+ITbAwk2QoMc6w==",
+      "version": "1.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-1.0.0-alpha.3.tgz",
+      "integrity": "sha512-/fX0+UvOegp8Mr9Ce6sqX/azblbm5K4yv8qyOHgdCAMkbGT2VQrSc8dMLZlO2A4D+1nmbXFQps1GJEGYRdxBHw==",
       "requires": {
-        "@jupyterlab/coreutils": "^2.2.1",
-        "@jupyterlab/observables": "^2.1.1",
+        "@jupyterlab/coreutils": "^3.0.0-alpha.3",
+        "@jupyterlab/observables": "^2.2.0-alpha.3",
         "@phosphor/coreutils": "^1.3.0",
         "@phosphor/disposable": "^1.1.2",
+        "@phosphor/dragdrop": "^1.3.0",
         "@phosphor/messaging": "^1.2.2",
         "@phosphor/signaling": "^1.2.2",
-        "@phosphor/widgets": "^1.6.0",
-        "react": "~16.4.2",
-        "react-dom": "~16.4.2"
+        "@phosphor/widgets": "^1.6.0"
       }
     },
     "@jupyterlab/codemirror": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/codemirror/-/codemirror-0.19.1.tgz",
-      "integrity": "sha512-JbZRm9vW1lN4Y4VghBQEys7vWoaZM54E0OdTlWjJq1kF8WhKWzp8Do/tnQ5fKVUGw40BMB0xBnfAaHHCSs5vHw==",
+      "version": "1.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/codemirror/-/codemirror-1.0.0-alpha.3.tgz",
+      "integrity": "sha512-yOVNbvngFNqoiczqmTmxow2/TAw30KQvVxYQ662cZXk6Ow4YlKZr5IubRKrJ2XbazC5eto/t5NQHMrAkpUhMLA==",
       "requires": {
-        "@jupyterlab/apputils": "^0.19.1",
-        "@jupyterlab/codeeditor": "^0.19.1",
-        "@jupyterlab/coreutils": "^2.2.1",
-        "@jupyterlab/observables": "^2.1.1",
+        "@jupyterlab/apputils": "^1.0.0-alpha.3",
+        "@jupyterlab/codeeditor": "^1.0.0-alpha.3",
+        "@jupyterlab/coreutils": "^3.0.0-alpha.3",
+        "@jupyterlab/observables": "^2.2.0-alpha.3",
+        "@jupyterlab/statusbar": "^1.0.0-alpha.3",
         "@phosphor/algorithm": "^1.1.2",
+        "@phosphor/commands": "^1.6.1",
         "@phosphor/coreutils": "^1.3.0",
         "@phosphor/disposable": "^1.1.2",
         "@phosphor/signaling": "^1.2.2",
-        "codemirror": "~5.39.0"
+        "@phosphor/widgets": "^1.6.0",
+        "codemirror": "~5.42.0",
+        "react": "~16.4.2"
       }
     },
     "@jupyterlab/coreutils": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-2.2.1.tgz",
-      "integrity": "sha512-XkGMBXqEAnENC4fK/L3uEqqxyNUtf4TI/1XNDln7d5VOPHQJSBTbYlBAZ0AQotn2qbs4WqmV6icxje2ITVedqQ==",
+      "version": "3.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.0.0-alpha.3.tgz",
+      "integrity": "sha512-rgEmh4wATssaxMvcC+SbrQzRAwG8hX720+MwSLW/LJjtp2/x7jX7vOqYvcpJ+fQYbEmh8aJjNuzy/t8DPi9ikg==",
       "requires": {
-        "@phosphor/algorithm": "^1.1.2",
         "@phosphor/coreutils": "^1.3.0",
         "@phosphor/disposable": "^1.1.2",
         "@phosphor/signaling": "^1.2.2",
-        "ajv": "~5.1.6",
+        "ajv": "^6.5.5",
         "comment-json": "^1.1.3",
         "minimist": "~1.2.0",
         "moment": "~2.21.0",
@@ -99,18 +147,18 @@
       }
     },
     "@jupyterlab/docregistry": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/docregistry/-/docregistry-0.19.1.tgz",
-      "integrity": "sha512-Brw+z+KwmcgQ7DnYuY3RniYf1Ecckwh3UG277XUdpqs+edITBZbhXgsRTIJc+ifLr8laTz04dqLUCJjwDBt8XA==",
+      "version": "1.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/docregistry/-/docregistry-1.0.0-alpha.3.tgz",
+      "integrity": "sha512-d75cFTTt/+YBlb+auVTa9Qdx9PaL6oL2FJwE8us64Qz6I4+ybU3MbRYGHAc7Jf9+QobeYlDCR1dyoOhZRddJxA==",
       "requires": {
-        "@jupyterlab/apputils": "^0.19.1",
-        "@jupyterlab/codeeditor": "^0.19.1",
-        "@jupyterlab/codemirror": "^0.19.1",
-        "@jupyterlab/coreutils": "^2.2.1",
-        "@jupyterlab/observables": "^2.1.1",
-        "@jupyterlab/rendermime": "^0.19.1",
-        "@jupyterlab/rendermime-interfaces": "^1.2.1",
-        "@jupyterlab/services": "^3.2.1",
+        "@jupyterlab/apputils": "^1.0.0-alpha.3",
+        "@jupyterlab/codeeditor": "^1.0.0-alpha.3",
+        "@jupyterlab/codemirror": "^1.0.0-alpha.3",
+        "@jupyterlab/coreutils": "^3.0.0-alpha.3",
+        "@jupyterlab/observables": "^2.2.0-alpha.3",
+        "@jupyterlab/rendermime": "^1.0.0-alpha.3",
+        "@jupyterlab/rendermime-interfaces": "^1.3.0-alpha.3",
+        "@jupyterlab/services": "^4.0.0-alpha.3",
         "@phosphor/algorithm": "^1.1.2",
         "@phosphor/coreutils": "^1.3.0",
         "@phosphor/disposable": "^1.1.2",
@@ -120,12 +168,12 @@
       }
     },
     "@jupyterlab/mainmenu": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/mainmenu/-/mainmenu-0.8.1.tgz",
-      "integrity": "sha512-2HHaDLlVA77rYBL9OFx5BYvXH765HRkNZBiqN86i90aWqh164QD7F7C46qi58xTQRjWLKMGhgvxAdpy61AxhEA==",
+      "version": "1.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/mainmenu/-/mainmenu-1.0.0-alpha.3.tgz",
+      "integrity": "sha512-ODT7rMecjcN1Q61yBR3fHFei36Wx2gjxfj5Jc6gvh356Wyk9SPvVMXsLyetnQYMoYQOt5OvKd9DBxCzH5XBBqA==",
       "requires": {
-        "@jupyterlab/apputils": "^0.19.1",
-        "@jupyterlab/services": "^3.2.1",
+        "@jupyterlab/apputils": "^1.0.0-alpha.3",
+        "@jupyterlab/services": "^4.0.0-alpha.3",
         "@phosphor/algorithm": "^1.1.2",
         "@phosphor/commands": "^1.6.1",
         "@phosphor/coreutils": "^1.3.0",
@@ -134,9 +182,9 @@
       }
     },
     "@jupyterlab/observables": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.1.1.tgz",
-      "integrity": "sha512-PzmJ/jF5fWzHCvjPAWBi3YjtHRAF0bwyjpd8W8aJt64TzhEZh0se8xCNGOURzD+8TxOsTF9JpQ9wIDBr4V226Q==",
+      "version": "2.2.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.2.0-alpha.3.tgz",
+      "integrity": "sha512-0rQcAymQ4F1eJY+KINHA7z70ov2gZcIPOZUPH+DSytw53qIi/Vy++Ybz7od1kFbqq6rZXuBv/57N/REJatK6CA==",
       "requires": {
         "@phosphor/algorithm": "^1.1.2",
         "@phosphor/coreutils": "^1.3.0",
@@ -146,45 +194,77 @@
       }
     },
     "@jupyterlab/rendermime": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime/-/rendermime-0.19.1.tgz",
-      "integrity": "sha512-MD+/lMwFa/b9QtJyFghTXFqkuRha74+vWTaPcfzREdHRiKYHYPHWOD/gb8cLIr4c7J3VaEVZWEpI8udYgyANvA==",
+      "version": "1.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime/-/rendermime-1.0.0-alpha.3.tgz",
+      "integrity": "sha512-n5FtQLKo+Aewc+I7k5zFuFm7nvhgD6kS+dLo7j6Akt9npptQJBdI2VScLEcnr9fZDp0yQfrEm8xG9uOUT/dIeg==",
       "requires": {
-        "@jupyterlab/apputils": "^0.19.1",
-        "@jupyterlab/codemirror": "^0.19.1",
-        "@jupyterlab/coreutils": "^2.2.1",
-        "@jupyterlab/observables": "^2.1.1",
-        "@jupyterlab/rendermime-interfaces": "^1.2.1",
-        "@jupyterlab/services": "^3.2.1",
+        "@jupyterlab/apputils": "^1.0.0-alpha.3",
+        "@jupyterlab/codemirror": "^1.0.0-alpha.3",
+        "@jupyterlab/coreutils": "^3.0.0-alpha.3",
+        "@jupyterlab/observables": "^2.2.0-alpha.3",
+        "@jupyterlab/rendermime-interfaces": "^1.3.0-alpha.3",
+        "@jupyterlab/services": "^4.0.0-alpha.3",
         "@phosphor/algorithm": "^1.1.2",
         "@phosphor/coreutils": "^1.3.0",
         "@phosphor/messaging": "^1.2.2",
         "@phosphor/signaling": "^1.2.2",
         "@phosphor/widgets": "^1.6.0",
-        "ansi_up": "^3.0.0",
-        "marked": "~0.4.0"
+        "lodash.escape": "^4.0.1",
+        "marked": "0.5.1"
       }
     },
     "@jupyterlab/rendermime-interfaces": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-1.2.1.tgz",
-      "integrity": "sha512-0kKRNbqsZSQwVEUuh/YhRZA8NNCJjr9R+Fte9FJeYx6j2LLr+FvYSX7PK5ysVb22w8sxmCW58km52MlDBIy7Gg==",
+      "version": "1.3.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-1.3.0-alpha.3.tgz",
+      "integrity": "sha512-h2hXWh4L9hfZHgWCWVT1symbGT60sNqyLRCzgYLvgJj3xVLO+dIb5BAsh/gNIO7gHVIhR6wBpuBDrIgK01Z3yQ==",
       "requires": {
         "@phosphor/coreutils": "^1.3.0",
         "@phosphor/widgets": "^1.6.0"
       }
     },
     "@jupyterlab/services": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-3.2.1.tgz",
-      "integrity": "sha512-zCMruGGYxTe427ESK4YUO1V/liFOFYpebYPRsJ+j9CFdV+Hm760+nx4pFX6N6Z9TbS+5cs8BgZ+ebm8unRZrJg==",
+      "version": "4.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.0.0-alpha.3.tgz",
+      "integrity": "sha512-AkmhtYRFymO/FlxUkEu5ELT3bsi6CLkkEFut7garGwQHl90SsMqYHSFwvbWS2Vpe5et7d/O4qIwWfhDqY9ANQw==",
       "requires": {
-        "@jupyterlab/coreutils": "^2.2.1",
-        "@jupyterlab/observables": "^2.1.1",
+        "@jupyterlab/coreutils": "^3.0.0-alpha.3",
+        "@jupyterlab/observables": "^2.2.0-alpha.3",
         "@phosphor/algorithm": "^1.1.2",
         "@phosphor/coreutils": "^1.3.0",
         "@phosphor/disposable": "^1.1.2",
-        "@phosphor/signaling": "^1.2.2"
+        "@phosphor/signaling": "^1.2.2",
+        "node-fetch": "~2.2.0",
+        "ws": "~6.0.0"
+      }
+    },
+    "@jupyterlab/statusbar": {
+      "version": "1.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/statusbar/-/statusbar-1.0.0-alpha.3.tgz",
+      "integrity": "sha512-rFqPgKdLqrsRQX1zxCMIziS0K4T9Ly8z0kvy6m8G1obPiN1S36wk4KG3tKOJNFRyDRckPp9ptKipSOZVFPysig==",
+      "requires": {
+        "@jupyterlab/apputils": "^1.0.0-alpha.3",
+        "@jupyterlab/codeeditor": "^1.0.0-alpha.3",
+        "@jupyterlab/coreutils": "^3.0.0-alpha.3",
+        "@jupyterlab/services": "^4.0.0-alpha.3",
+        "@phosphor/algorithm": "^1.1.2",
+        "@phosphor/coreutils": "^1.3.0",
+        "@phosphor/disposable": "^1.1.2",
+        "@phosphor/messaging": "^1.2.2",
+        "@phosphor/signaling": "^1.2.2",
+        "@phosphor/widgets": "^1.6.0",
+        "react": "~16.4.2",
+        "typestyle": "^2.0.1"
+      }
+    },
+    "@jupyterlab/ui-components": {
+      "version": "1.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-1.0.0-alpha.3.tgz",
+      "integrity": "sha512-kFz7XultrTZhz+QPejp8mN3VQkjl3rMJY4KYEGExtQTgse1Y9ar/DLGhB6RpdutoLvUgl9bVvs9J7hHL7jsHhA==",
+      "requires": {
+        "@blueprintjs/core": "^3.9.0",
+        "@blueprintjs/icons": "^3.3.0",
+        "@blueprintjs/select": "^3.3.0",
+        "react": "~16.4.2"
       }
     },
     "@phosphor/algorithm": {
@@ -303,10 +383,15 @@
         "@phosphor/virtualdom": "^1.1.2"
       }
     },
+    "@types/dom4": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/dom4/-/dom4-2.0.1.tgz",
+      "integrity": "sha512-kSkVAvWmMZiCYtvqjqQEwOmvKwcH+V4uiv3qPQ8pAh1Xl39xggGEo8gHUqV4waYGHezdFw0rKBR8Jt0CrQSDZA=="
+    },
     "@types/prop-types": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.6.tgz",
-      "integrity": "sha512-ZBFR7TROLVzCkswA3Fmqq+IIJt62/T7aY/Dmz+QkU7CaW2QFqAitCE8Ups7IzmGhcN1YWMBT4Qcoc07jU9hOJQ=="
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.0.tgz",
+      "integrity": "sha512-eItQyV43bj4rR3JPV0Skpl1SncRCdziTEK9/v8VwXmV6d/qOUO8/EuWeHBbCZcsfSHfzI5UyMJLCSXtxxznyZg=="
     },
     "@types/react": {
       "version": "16.4.18",
@@ -318,13 +403,14 @@
       }
     },
     "ajv": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.1.6.tgz",
-      "integrity": "sha1-Sy8aGd7Ok9V6whYDfj6XkcfdFWQ=",
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
       "requires": {
-        "co": "^4.6.0",
-        "json-schema-traverse": "^0.3.0",
-        "json-stable-stringify": "^1.0.1"
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       }
     },
     "ansi-styles": {
@@ -334,11 +420,6 @@
       "requires": {
         "color-convert": "^1.9.0"
       }
-    },
-    "ansi_up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi_up/-/ansi_up-3.0.0.tgz",
-      "integrity": "sha1-J/Rdj0V9nO/1nk6gPI5vE8GjA+g="
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -350,25 +431,46 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "chalk": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
     },
-    "co": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+    "classnames": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
     "codemirror": {
-      "version": "5.39.2",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.39.2.tgz",
-      "integrity": "sha512-mchBy0kQ1Wggi+e58SmoLgKO4nG7s/BqNg6/6TRbhsnXI/KRG+fKAvRQ1LLhZZ6ZtUoDQ0dl5aMhE+IkSRh60Q=="
+      "version": "5.42.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.42.2.tgz",
+      "integrity": "sha512-Tkv6im39VuhduFMsDA3MlXcC/kKas3Z0PI1/8N88QvFQbtOeiiwnfFJE4juGyC8/a4sb1BSxQlzsil8XLQdxRw=="
     },
     "color-convert": {
       "version": "1.9.3",
@@ -391,41 +493,57 @@
         "json-parser": "^1.0.0"
       }
     },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
     "core-js": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
       "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
     },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
-    "csstype": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.7.tgz",
-      "integrity": "sha512-Nt5VDyOTIIV4/nRFswoCKps1R5CD1hkiyjBE9/thNaNZILLEviVw9yWQw15+O+CpNjQKB/uvdcxFFOrSflY3Yw=="
-    },
-    "dom-serializer": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+    "create-react-context": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.2.tgz",
+      "integrity": "sha512-KkpaLARMhsTsgp0d2NA/R94F/eDLbhXERdIq3LvX2biCAXcDvHYoOqHfWCHf1+OLj+HKBotLG3KqaOOf+C1C+A==",
       "requires": {
-        "domelementtype": "~1.1.1",
-        "entities": "~1.1.1"
-      },
-      "dependencies": {
-        "domelementtype": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
-        }
+        "fbjs": "^0.8.0",
+        "gud": "^1.0.0"
       }
     },
+    "csstype": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.3.tgz",
+      "integrity": "sha512-rINUZXOkcBmoHWEyu7JdHu5JMzkGRoMX4ov9830WNgxf5UYxcBUO0QTKAqeJ5EZfSdlrcJYkC8WwfVW7JYi4yg=="
+    },
+    "dom-helpers": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
+    "dom-serializer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+      "requires": {
+        "domelementtype": "^1.3.0",
+        "entities": "^1.1.1"
+      }
+    },
+    "dom4": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/dom4/-/dom4-2.1.4.tgz",
+      "integrity": "sha512-7NNKNViuZYu4GaZMUsSbsV6MFsT/ZpYNKP1NT4YIUgAvwPR8ODuvQEZZ7vRC1u5Y4dHwQ7je/UNOlRRWkaCyvw=="
+    },
     "domelementtype": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
     },
     "domhandler": {
       "version": "2.4.2",
@@ -453,9 +571,9 @@
       }
     },
     "entities": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -466,6 +584,16 @@
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
       "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fbjs": {
       "version": "0.8.17",
@@ -481,22 +609,57 @@
         "ua-parser-js": "^0.7.18"
       }
     },
+    "font-awesome": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
+      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
+    },
+    "free-style": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/free-style/-/free-style-2.5.1.tgz",
+      "integrity": "sha512-X7dtUSTrlS1KRQBtiQ618NWIRDdRgD91IeajKCSh0fgTqArSixv+n3ea6F/OSvrvg14tPLR+yCq2s+O602+pRw=="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "gud": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "htmlparser2": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
-      "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
       "requires": {
-        "domelementtype": "^1.3.0",
+        "domelementtype": "^1.3.1",
         "domhandler": "^2.3.0",
         "domutils": "^1.5.1",
         "entities": "^1.1.1",
         "inherits": "^2.0.1",
-        "readable-stream": "^2.0.2"
+        "readable-stream": "^3.1.1"
       }
     },
     "iconv-lite": {
@@ -505,6 +668,16 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -517,11 +690,6 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-    },
     "isomorphic-fetch": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
@@ -529,6 +697,17 @@
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
       }
     },
     "js-tokens": {
@@ -545,27 +724,19 @@
       }
     },
     "json-schema-traverse": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-    },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "requires": {
-        "jsonify": "~0.0.0"
-      }
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
+    "lodash.escape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
+      "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg="
     },
     "lodash.escaperegexp": {
       "version": "4.1.2",
@@ -596,28 +767,38 @@
       }
     },
     "marked": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
-      "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw=="
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.5.1.tgz",
+      "integrity": "sha512-iUkBZegCZou4AdwbKTwSW/lNDcz5OuRSl3qdcl31Ia0B2QPG0Jn+tKblh/9/eP9/6+4h27vpoh8wel/vQOV0vw=="
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
     },
     "minimist": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "moment": {
       "version": "2.21.0",
-      "resolved": "http://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.21.0.tgz",
       "integrity": "sha512-TCZ36BjURTeFTM/CwRcViQlfkMvL1/vFISuNLO5GkcVm1+QHfbSiNqZuWeMFjj1/3+uAjXswgRk30j1kkLYJBQ=="
     },
     "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.1.tgz",
+      "integrity": "sha512-ObXBpNCD3A/vYQiQtEWl7DuqjAXjfptYFuGHLdPl5U19/6kJuZV+8uMHLrkj3wJrJoyfg4nhgyFixZdaZoAiEQ=="
+    },
+    "normalize.css": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
+      "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg=="
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -629,10 +810,30 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
     "path-posix": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/path-posix/-/path-posix-1.0.0.tgz",
       "integrity": "sha1-BrJhE/Vr6rBCVFojv6iAA8ysJg8="
+    },
+    "popper.js": {
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.7.tgz",
+      "integrity": "sha512-4q1hNvoUre/8srWsH7hnoSJ5xVmIL4qgz+s4qf2TnJIMyZFUFMGH+9vE7mXynAlHSZ/NdTmmow86muD0myUkVQ=="
     },
     "postcss": {
       "version": "6.0.23",
@@ -644,11 +845,6 @@
         "supports-color": "^5.4.0"
       }
     },
-    "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
-    },
     "promise": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
@@ -658,18 +854,24 @@
       }
     },
     "prop-types": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
       "requires": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
       }
     },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
     "querystringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
-      "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg=="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
     },
     "react": {
       "version": "16.4.2",
@@ -693,24 +895,73 @@
         "prop-types": "^15.6.0"
       }
     },
-    "readable-stream": {
-      "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+    "react-is": {
+      "version": "16.8.5",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.5.tgz",
+      "integrity": "sha512-sudt2uq5P/2TznPV4Wtdi+Lnq3yaYW8LfvPKLM9BKD8jJNBkxMVyB0C9/GmVhLw7Jbdmndk/73n7XQGeN9A3QQ=="
+    },
+    "react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+    },
+    "react-popper": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.3.tgz",
+      "integrity": "sha512-ynMZBPkXONPc5K4P5yFWgZx5JGAUIP3pGGLNs58cfAPgK67olx7fmLp+AdpZ0+GoQ+ieFDa/z4cdV6u7sioH6w==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "@babel/runtime": "^7.1.2",
+        "create-react-context": "<=0.2.2",
+        "popper.js": "^1.14.4",
+        "prop-types": "^15.6.1",
+        "typed-styles": "^0.0.7",
+        "warning": "^4.0.2"
       }
+    },
+    "react-transition-group": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.7.0.tgz",
+      "integrity": "sha512-CzF22K0x6arjQO4AxkasMaiYcFG/QH0MhPNs45FmNsfWsQmsO9jv52sIZJAalnlryD5RgrrbLtV5CMJSokrrMA==",
+      "requires": {
+        "dom-helpers": "^3.3.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2",
+        "react-lifecycles-compat": "^3.0.4"
+      }
+    },
+    "readable-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
+      "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
     },
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+    },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -759,9 +1010,9 @@
       }
     },
     "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
+      "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -774,15 +1025,48 @@
         "has-flag": "^3.0.0"
       }
     },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+    },
+    "typed-styles": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
+      "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
+    },
+    "typescript": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
+      "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+      "dev": true
+    },
+    "typestyle": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/typestyle/-/typestyle-2.0.1.tgz",
+      "integrity": "sha512-3Mv5ZZbYJ3y3G6rX3iRLrgYibAlafK2nsc9VlTsYcEaK8w+9vtNDx0T2TJsznI5FIh+WoBnjJ5F0/26WaGRxXQ==",
+      "requires": {
+        "csstype": "^2.4.0",
+        "free-style": "2.5.1"
+      }
+    },
     "ua-parser-js": {
-      "version": "0.7.18",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.18.tgz",
-      "integrity": "sha512-LtzwHlVHwFGTptfNSgezHp7WUlwiqb0gA9AALRbKaERfxwJoiX0A73QbTToxteIAuIaFshhgIZfqK8s7clqgnA=="
+      "version": "0.7.19",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.19.tgz",
+      "integrity": "sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ=="
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "requires": {
+        "punycode": "^2.1.0"
+      }
     },
     "url-parse": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
-      "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
+      "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
       "requires": {
         "querystringify": "^2.0.0",
         "requires-port": "^1.0.0"
@@ -793,10 +1077,32 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
+    "warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "whatwg-fetch": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
       "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "ws": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.0.0.tgz",
+      "integrity": "sha512-c2UlYcAZp1VS8AORtpq6y4RJIkJ9dQz18W32SpR/qXGfLDZ2jU4y4wKvvZwqbi7U6gxFQTeE+urMbXU/tsDy4w==",
+      "requires": {
+        "async-limiter": "~1.0.0"
+      }
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@jupyterlab/application": "^0.19.1",
-    "@jupyterlab/apputils": "^0.19.1",
-    "@jupyterlab/coreutils": "^2.2.1",
-    "@jupyterlab/mainmenu": "^0.8.1",
+    "@jupyterlab/application": "^1.0.0-alpha.1",
+    "@jupyterlab/apputils": "^1.0.0-alpha.1",
+    "@jupyterlab/coreutils": "^3.0.0-alpha.3",
+    "@jupyterlab/mainmenu": "^1.0.0-alpha.3",
     "@phosphor/widgets": "^1.6.0"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {
 } from '@jupyterlab/apputils';
 
 import {
-  JupyterLab, JupyterLabPlugin
+  JupyterLab, JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 
 import {
@@ -196,7 +196,7 @@ function activateHubExtension(app: JupyterLab, palette: ICommandPalette, mainMen
 /**
  * Initialization data for the jupyterlab_hub extension.
  */
-const hubExtension: JupyterLabPlugin<void> = {
+const hubExtension: JupyterFrontEndPlugin<void> = {
   activate: activateHubExtension,
   id: 'jupyter.extensions.jupyterlab-hub',
   requires: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,8 +14,16 @@ import {
 } from '@jupyterlab/application';
 
 import {
+  Dialog, showDialog
+} from '@jupyterlab/apputils';
+
+import {
   PageConfig, URLExt
 } from '@jupyterlab/coreutils';
+
+import {
+  ServerConnection
+} from '@jupyterlab/services';
 
 import {
   IMainMenu
@@ -27,64 +35,163 @@ import {
 export
 namespace CommandIDs {
   export
-  const controlPanel: string = 'hub:control-panel';
+    const controlPanel: string = 'hub:control-panel';
 
   export
-  const logout: string = 'hub:logout';
+    const logout: string = 'hub:logout';
+
+  export
+    const restartServer: string = 'hub:restart-server';
 };
 
+const checkInterval: number = 7000;
+
+export class HubExtension {
+
+  protected serverConnectionSettings: ServerConnection.ISettings;
+  protected app: JupyterLab;
+  protected status: string;
+  protected hubHost: string;
+  protected hubPrefix: string;
+  protected baseUrl: string;
+  protected restartUrl: string;
+
+  constructor() {
+    this.serverConnectionSettings = ServerConnection.makeSettings();
+    this.status = 'ok';
+
+    // This config is provided by JupyterHub to the single-user server app
+    // in a dictionary: app.web_app.settings['page_config_data'].
+    this.hubHost = PageConfig.getOption('hub_host');
+    this.hubPrefix = PageConfig.getOption('hub_prefix');
+    this.baseUrl = PageConfig.getOption('baseUrl');
+
+    if (!this.hubPrefix) {
+      console.warn('jupyterlab-hub: No configuration found.');
+      return;
+    }
+
+    console.debug('jupyterlab-hub: Found configuration ',
+      {
+        hubHost: this.hubHost,
+        hubPrefix: this.hubPrefix,
+        baseUrl: this.baseUrl,
+      }
+    );
+    // TODO: use /spawn/:user/:name
+    // but that requires jupyterhub 1.0
+    // and jupyterlab to pass username, servername to PageConfig
+    this.restartUrl = this.hubHost + URLExt.join(this.hubPrefix, `spawn?next=${this.hubPrefix}home`);
+  }
+
+  activate(app: JupyterLab, palette: ICommandPalette, mainMenu: IMainMenu): void {
+
+    this.app = app;
+    const category = 'Hub';
+
+    const { commands } = app;
+
+    commands.addCommand(CommandIDs.controlPanel, {
+      label: 'Control Panel',
+      caption: 'Open the Hub control panel in a new browser tab',
+      execute: () => {
+        window.open(this.hubHost + URLExt.join(this.hubPrefix, 'home'), '_blank');
+      }
+    });
+
+    commands.addCommand(CommandIDs.logout, {
+      label: 'Logout',
+      caption: 'Log out of the Hub',
+      execute: () => {
+        window.location.href = this.hubHost + URLExt.join(this.baseUrl, 'logout');
+      }
+    });
+
+    commands.addCommand(CommandIDs.restartServer, {
+      label: 'Restart Server',
+      caption: 'Request that the Hub restart this server',
+      execute: () => {
+        window.open(this.restartUrl, '_blank');
+      }
+    });
+
+    // Add commands and menu items.
+    let menu = new Menu({ commands });
+    menu.title.label = category;
+    [
+      CommandIDs.controlPanel,
+      CommandIDs.logout,
+      CommandIDs.restartServer,
+    ].forEach(command => {
+      palette.addItem({ command, category });
+      menu.addItem({ command });
+    });
+    mainMenu.addMenu(menu, { rank: 100 });
+
+    window.setInterval(() => {
+      if (document.hidden) {
+        // don't poll if the window is not frontmost
+        return;
+      }
+      this.checkStatus();
+      // add some randomness to the poll
+      // so that each user is on a slightly different interval
+    }, checkInterval * (1 + 0.25 * Math.random()));
+  }
+
+  checkStatus(): void {
+    const { commands } = this.app;
+    const url = new URL(
+      'api/status',
+      this.serverConnectionSettings.baseUrl
+    );
+    const request = ServerConnection.makeRequest(
+      url.toString(),
+      {},
+      this.serverConnectionSettings
+    ).then(response => {
+      if (!response.ok) {
+        throw new Error(`${response.status} (${response.statusText})`);
+      }
+      return response.json();
+    }
+    );
+    request.then(
+      () => {
+        this.status = 'ok';
+      },
+      reason => {
+        if (this.status == 'failed') {
+          // avoid repeatedly showing this dialog for a single error
+          // until the next successful check
+          return;
+        }
+        this.status = 'failed';
+        showDialog({
+          title: "Server not running",
+          body: `Your server at ${this.baseUrl} is not running.
+          You may restart it by clicking the link below,
+          or visiting ${this.restartUrl}`,
+          buttons: [
+            Dialog.okButton({
+              label: 'Restart server',
+            }),
+            Dialog.cancelButton({ label: 'Dismiss' }),
+          ]
+        }).then(result => result.button.accept ?
+          commands.execute(CommandIDs.restartServer) : null);
+      }
+    );
+  }
+}
 
 /**
  * Activate the jupyterhub extension.
  */
 function activateHubExtension(app: JupyterLab, palette: ICommandPalette, mainMenu: IMainMenu): void {
-
-  // This config is provided by JupyterHub to the single-user server app
-  // in a dictionary: app.web_app.settings['page_config_data'].
-  let hubHost = PageConfig.getOption('hub_host');
-  let hubPrefix = PageConfig.getOption('hub_prefix');
-  let baseUrl = PageConfig.getOption('baseUrl');
-
-  if (!hubPrefix) {
-    console.log('jupyterlab-hub: No configuration found.');
-    return;
-  }
-
-  console.log('jupyterlab-hub: Found configuration ',
-              {hubHost: hubHost, hubPrefix: hubPrefix});
-
-  const category = 'Hub';
-  const { commands } = app;
-
-  commands.addCommand(CommandIDs.controlPanel, {
-    label: 'Control Panel',
-    caption: 'Open the Hub control panel in a new browser tab',
-    execute: () => {
-      window.open(hubHost + URLExt.join(hubPrefix, 'home'), '_blank');
-    }
-  });
-
-  commands.addCommand(CommandIDs.logout, {
-    label: 'Logout',
-    caption: 'Log out of the Hub',
-    execute: () => {
-      window.location.href = hubHost + URLExt.join(baseUrl, 'logout');
-    }
-  });
-
-  // Add commands and menu itmes.
-  let menu = new Menu({ commands });
-  menu.title.label = category;
-  [
-    CommandIDs.controlPanel,
-    CommandIDs.logout,
-  ].forEach(command => {
-    palette.addItem({ command, category });
-    menu.addItem({ command });
-  });
-  mainMenu.addMenu(menu, {rank: 100});
+  let theExtension = new HubExtension();
+  theExtension.activate(app, palette, mainMenu);
 }
-
 
 /**
  * Initialization data for the jupyterlab_hub extension.


### PR DESCRIPTION
polls /api/status, showing dialog on failure

- adds restart-server action
- restart-server action opens new tab pointed to /hub/spawn to trigger the new spawn

Improvements that could be made:

1. restart with API request instead of new tab (not reliable because API token may not still be valid with the Hub after stop)
2. use `/hub/spawn/:user/:server` spawn urls, which are new in Hub 1.0. This PR won't properly restart named servers. This also requires jupyterlab to make the username and server name available to PageConfig (or we can parse the url).
3. hook into lab's existing Connection Lost event

Fixes #83

**Screenshots**

<img width="588" alt="Screen Shot 2019-03-25 at 15 36 05" src="https://user-images.githubusercontent.com/151929/54928397-20381f80-4f14-11e9-85c0-31741a573879.png">
